### PR TITLE
Fix: Resolve ReferenceErrors in MessageBubble and ChatPage

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -42,9 +42,11 @@ interface ChatMessage {
 
 interface MessageBubbleProps {
   message: ChatMessage;
+  hasThinkingData: (messageId: string) => boolean;
+  onViewThinking: (messageId: string) => void;
 }
 
-const MessageBubble = ({ message }: MessageBubbleProps) => {
+const MessageBubble = ({ message, hasThinkingData, onViewThinking }: MessageBubbleProps) => {
   if (message.type === "user") {
     return (
       <div className="flex justify-end">

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -32,7 +32,7 @@ import {
   fileProcessingService,
   type FileProcessingResult,
 } from "@/services/fileProcessingService";
-import type { MindMapNode as IMindMapNode, MindMapEdge as IMindMapEdge } from "@/services/mindMapService"; // For stricter typing if needed
+import { mindMapService, type MindMapNode as IMindMapNode, type MindMapEdge as IMindMapEdge } from "@/services/mindMapService"; // For stricter typing if needed
 
 interface ChatMessage {
   id: string;


### PR DESCRIPTION
This commit addresses two ReferenceErrors:

1.  `hasThinkingData is not defined` in `MessageBubble.tsx`: The `MessageBubbleProps` interface was updated to correctly include `hasThinkingData` and `onViewThinking` props. The component's props destructuring was also updated to receive these new props. This ensures that `MessageBubble` can correctly determine if thinking data is available and handle the action to view it.

2.  `mindMapService is not defined` in `ChatPage.tsx`: The import statement for `mindMapService` in `ChatPage.tsx` was corrected to import the actual service instance instead of just its types. This allows the `ChatPage` component to correctly call methods on `mindMapService` for mind map generation and expansion.